### PR TITLE
Removed unused matplotlib import in label_propagation.py

### DIFF
--- a/evoc/label_propagation.py
+++ b/evoc/label_propagation.py
@@ -186,9 +186,6 @@ def original_label_prop_loop(
     return remap_labels(labels)
 
 
-import matplotlib.pyplot as plt
-
-
 def label_propagation_init(
     graph,
     n_label_prop_iter=20,


### PR DESCRIPTION
matplotlib.pyplot is imported at module level in label_propagation.py but never used. Since matplotlib is not a declared dependency in pyproject.toml, this causes a ModuleNotFoundError on import evoc in environments without matplotlib installed. The CI hides this because it installs matplotlib.