### PR TITLE
docs: add Read the Docs link to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,13 @@ EVōC is the library to use if you want:
  As of now this is very much an early beta version of the library. Things can and will break right now.
  We would welcome feedback, use cases and feature suggestions however.
 
+-------------
+Documentation
+-------------
+
+The full documentation is available on Read the Docs:
+`https://evoc.readthedocs.io/en/latest/ <https://evoc.readthedocs.io/en/latest/>`_
+
 -----------
 Basic Usage
 -----------


### PR DESCRIPTION
## Summary
- Add a Documentation section to `README.rst` file.
- Include a direct link to the hosted docs on Read the Docs.

## Why
The docs site link is currently missing from the README, making it harder for new users to find detailed usage and API docs.