### PR TITLE
feat: add GPU-native acceleration via PyTorch (CUDA/MPS)

### DIFF
--- a/evoc/__init__.py
+++ b/evoc/__init__.py
@@ -1,1 +1,2 @@
 from .clustering import evoc_clusters, EVoC
+from .gpu import gpu_available

--- a/evoc/clustering.py
+++ b/evoc/clustering.py
@@ -207,6 +207,7 @@ def evoc_clusters(
     min_similarity_threshold=0.2,
     max_layers=10,
     n_label_prop_iter=20,
+    use_gpu=False,
 ):
     """Cluster data using the EVoC algorithm.
 
@@ -305,6 +306,12 @@ def evoc_clusters(
         The number of iterations to use in the label propagation algorithm when
         initializing the node embedding.
 
+    use_gpu : bool or str, default=False
+        Whether to use GPU acceleration for the most compute-intensive steps
+        (KNN graph, graph construction, node embedding). If ``"auto"``, GPU is
+        used when a supported backend (CUDA, MPS) is detected. If True, raises
+        an error when no GPU is available. Requires PyTorch to be installed.
+
     Returns
     -------
 
@@ -329,12 +336,42 @@ def evoc_clusters(
     if random_state is None:
         random_state = np.random.RandomState()
 
-    nn_inds, nn_dists = knn_graph(
-        data, n_neighbors=n_neighbors, random_state=random_state
-    )
-    graph = neighbor_graph_matrix(
-        neighbor_scale * n_neighbors, nn_inds, nn_dists, symmetrize_graph
-    )
+    # Resolve GPU flag: "auto" checks availability, True requires GPU
+    _use_gpu = False
+    if use_gpu == "auto":
+        try:
+            from .gpu import gpu_available
+            _use_gpu = gpu_available()
+        except ImportError:
+            _use_gpu = False
+    elif use_gpu:
+        from .gpu import gpu_available
+        if not gpu_available():
+            raise RuntimeError(
+                "use_gpu=True but no GPU backend found. "
+                "Install PyTorch with CUDA/MPS support, or set use_gpu=False."
+            )
+        _use_gpu = True
+
+    if _use_gpu:
+        from .gpu.knn_gpu import knn_graph_gpu
+        from .gpu.graph_construction_gpu import neighbor_graph_matrix_gpu
+        from .gpu.node_embedding_gpu import node_embedding_gpu
+
+        nn_inds, nn_dists = knn_graph_gpu(
+            data, n_neighbors=n_neighbors
+        )
+        graph = neighbor_graph_matrix_gpu(
+            neighbor_scale * n_neighbors, nn_inds, nn_dists, symmetrize_graph
+        )
+    else:
+        nn_inds, nn_dists = knn_graph(
+            data, n_neighbors=n_neighbors, random_state=random_state
+        )
+        graph = neighbor_graph_matrix(
+            neighbor_scale * n_neighbors, nn_inds, nn_dists, symmetrize_graph
+        )
+
     n_embedding_components = node_embedding_dim or min(max(n_neighbors // 4, 4), 15)
     if node_embedding_init == "label_prop":
         init_embedding = label_propagation_init(
@@ -351,18 +388,32 @@ def evoc_clusters(
     elif node_embedding_init is None:
         init_embedding = None
 
-    embedding = node_embedding(
-        graph,
-        n_components=n_embedding_components,
-        n_epochs=n_epochs,
-        initial_embedding=init_embedding,
-        negative_sample_rate=1.0,
-        noise_level=noise_level,
-        random_state=random_state,
-        verbose=False,
-        reproducible_flag=reproducible_flag,
-        initial_alpha=0.1,
-    )
+    if _use_gpu:
+        embedding = node_embedding_gpu(
+            graph,
+            n_components=n_embedding_components,
+            n_epochs=n_epochs,
+            initial_embedding=init_embedding,
+            negative_sample_rate=1.0,
+            noise_level=noise_level,
+            random_state=random_state,
+            verbose=False,
+            reproducible_flag=reproducible_flag,
+            initial_alpha=0.1,
+        )
+    else:
+        embedding = node_embedding(
+            graph,
+            n_components=n_embedding_components,
+            n_epochs=n_epochs,
+            initial_embedding=init_embedding,
+            negative_sample_rate=1.0,
+            noise_level=noise_level,
+            random_state=random_state,
+            verbose=False,
+            reproducible_flag=reproducible_flag,
+            initial_alpha=0.1,
+        )
 
     if return_duplicates:
         duplicates = find_duplicates(nn_inds, nn_dists)
@@ -501,6 +552,11 @@ class EVoC(BaseEstimator, ClusterMixin):
         the label propagation process takes to converge when node_embedding_init
         is set to 'label_prop'.
 
+    use_gpu : bool or str, default=False
+        Whether to use GPU acceleration for KNN, graph construction, and node
+        embedding. Set to ``"auto"`` to use GPU when available, or True to require
+        it. Requires PyTorch with CUDA or MPS support.
+
     Attributes
     ----------
 
@@ -554,6 +610,7 @@ class EVoC(BaseEstimator, ClusterMixin):
         min_similarity_threshold: float = 0.2,
         max_layers: int = 10,
         n_label_prop_iter=20,
+        use_gpu: bool | str = False,
     ) -> None:
         self.n_neighbors = n_neighbors
         self.noise_level = noise_level
@@ -570,6 +627,7 @@ class EVoC(BaseEstimator, ClusterMixin):
         self.min_similarity_threshold = min_similarity_threshold
         self.max_layers = max_layers
         self.n_label_prop_iter = n_label_prop_iter
+        self.use_gpu = use_gpu
 
     def fit_predict(self, X, y=None, **fit_params):
         """Fit the model to the data and return the clustering labels.
@@ -631,6 +689,7 @@ class EVoC(BaseEstimator, ClusterMixin):
             min_similarity_threshold=self.min_similarity_threshold,
             max_layers=self.max_layers,
             n_label_prop_iter=self.n_label_prop_iter,
+            use_gpu=self.use_gpu,
         )
 
         if len(self.cluster_layers_) == 1:

--- a/evoc/gpu/__init__.py
+++ b/evoc/gpu/__init__.py
@@ -1,0 +1,79 @@
+"""GPU acceleration backend for EVoC clustering.
+
+Provides GPU-accelerated implementations of the most compute-intensive
+operations in the EVoC pipeline using PyTorch as the GPU backend.
+
+Supports CUDA (NVIDIA), ROCm (AMD), and MPS (Apple Silicon) devices.
+"""
+
+_GPU_AVAILABLE = False
+_GPU_BACKEND = None
+
+
+def _detect_gpu():
+    """Detect available GPU backend on import."""
+    global _GPU_AVAILABLE, _GPU_BACKEND
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            _GPU_AVAILABLE = True
+            _GPU_BACKEND = "cuda"
+        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            _GPU_AVAILABLE = True
+            _GPU_BACKEND = "mps"
+    except ImportError:
+        pass
+
+
+def gpu_available():
+    """Return True if a supported GPU backend is available."""
+    return _GPU_AVAILABLE
+
+
+def get_device():
+    """Get the PyTorch device for GPU operations.
+
+    Returns
+    -------
+    torch.device
+        The best available GPU device.
+
+    Raises
+    ------
+    RuntimeError
+        If no GPU backend is available.
+    """
+    import torch
+
+    if _GPU_BACKEND == "cuda":
+        return torch.device("cuda")
+    elif _GPU_BACKEND == "mps":
+        return torch.device("mps")
+    raise RuntimeError(
+        "No GPU available. Install PyTorch with CUDA or MPS support, "
+        "or set use_gpu=False."
+    )
+
+
+def _auto_batch_size(n_samples, n_features, element_bytes=4):
+    """Estimate batch size for GPU KNN that fits in GPU memory.
+
+    Uses ~40% of GPU memory for the similarity matrix computation,
+    accounting for the full dataset already being on-device.
+    """
+    import torch
+
+    if _GPU_BACKEND == "cuda":
+        total_mem = torch.cuda.get_device_properties(0).total_memory
+    else:
+        # MPS does not easily expose memory; assume 8GB
+        total_mem = 8 * 1024**3
+
+    data_bytes = n_samples * n_features * element_bytes
+    usable = max(int(total_mem * 0.4) - data_bytes, int(total_mem * 0.1))
+    bs = max(128, usable // max(n_samples * element_bytes, 1))
+    return min(bs, n_samples)
+
+
+_detect_gpu()

--- a/evoc/gpu/graph_construction_gpu.py
+++ b/evoc/gpu/graph_construction_gpu.py
@@ -1,0 +1,200 @@
+"""GPU-accelerated graph construction from KNN data.
+
+Ports the smooth_knn_dist binary search and membership strength computation
+to fully vectorized GPU operations via PyTorch.
+"""
+
+import numpy as np
+import torch
+
+from scipy.sparse import coo_array
+
+from . import get_device
+
+SMOOTH_K_TOLERANCE = 1e-5
+MIN_K_DIST_SCALE = 1e-3
+
+
+def smooth_knn_dist_gpu(distances, k, n_iter=64, bandwidth=1.0):
+    """GPU-accelerated computation of smooth KNN distances.
+
+    Vectorised binary search across all samples simultaneously on GPU.
+
+    Parameters
+    ----------
+    distances : ndarray of shape (n_samples, n_neighbors), float32
+        KNN distance matrix.
+
+    k : float
+        Effective number of neighbors for kernel width estimation.
+
+    n_iter : int, default=64
+        Maximum binary search iterations.
+
+    bandwidth : float, default=1.0
+        Kernel bandwidth scaling factor.
+
+    Returns
+    -------
+    sigma : ndarray of shape (n_samples,), float32
+    rho : ndarray of shape (n_samples,), float32
+    """
+    device = get_device()
+    target = np.log2(k) * bandwidth
+    n_samples, n_neighbors = distances.shape
+
+    dists = torch.from_numpy(distances.astype(np.float32)).to(device)
+    mean_distances = dists.mean().item()
+
+    # Compute rho: distance to nearest non-zero neighbor
+    dists_masked = dists.clone()
+    dists_masked[dists_masked <= 0] = float("inf")
+    rho = dists_masked.min(dim=1).values
+    rho[rho == float("inf")] = 0.0
+
+    # Binary search for sigma — fully vectorized across all samples
+    lo = torch.zeros(n_samples, device=device, dtype=torch.float32)
+    hi = torch.full((n_samples,), float("inf"), device=device, dtype=torch.float32)
+    mid = torch.ones(n_samples, device=device, dtype=torch.float32)
+
+    for _ in range(n_iter):
+        # psum = sum_{j=1..k} exp(-(d[i,j] - rho[i]) / mid[i]) if d>rho else 1
+        d = dists[:, 1:] - rho.unsqueeze(1)  # (n_samples, n_neighbors-1)
+        psum = torch.where(
+            d > 0,
+            torch.exp(-d / mid.unsqueeze(1).clamp(min=1e-10)),
+            torch.ones_like(d),
+        ).sum(dim=1)
+
+        converged = torch.abs(psum - target) < SMOOTH_K_TOLERANCE
+        too_high = psum > target
+        too_low = ~too_high & ~converged
+
+        # Update hi/lo/mid
+        hi = torch.where(too_high, mid, hi)
+        lo = torch.where(too_low, mid, lo)
+
+        inf_hi = hi == float("inf")
+        new_mid = torch.where(
+            too_high,
+            (lo + hi) / 2.0,
+            torch.where(
+                too_low & inf_hi,
+                mid * 2.0,
+                torch.where(too_low & ~inf_hi, (lo + hi) / 2.0, mid),
+            ),
+        )
+        mid = torch.where(converged, mid, new_mid)
+
+    sigma = mid
+
+    # Minimum distance scaling
+    mean_per_sample = dists.mean(dim=1)
+    rho_pos = rho > 0
+    sigma = torch.where(
+        rho_pos & (sigma < MIN_K_DIST_SCALE * mean_per_sample),
+        MIN_K_DIST_SCALE * mean_per_sample,
+        sigma,
+    )
+    sigma = torch.where(
+        ~rho_pos & (sigma < MIN_K_DIST_SCALE * mean_distances),
+        torch.full_like(sigma, MIN_K_DIST_SCALE * mean_distances),
+        sigma,
+    )
+
+    return sigma.cpu().numpy(), rho.cpu().numpy()
+
+
+def compute_membership_strengths_gpu(knn_indices, knn_dists, sigmas, rhos):
+    """GPU-accelerated membership strength computation.
+
+    Computes the Gaussian kernel weights for each KNN edge in parallel on GPU.
+
+    Parameters
+    ----------
+    knn_indices : ndarray of shape (n_samples, n_neighbors), int32
+    knn_dists : ndarray of shape (n_samples, n_neighbors), float32
+    sigmas : ndarray of shape (n_samples,), float32
+    rhos : ndarray of shape (n_samples,), float32
+
+    Returns
+    -------
+    rows, cols, vals : ndarrays
+        COO format sparse matrix components.
+    """
+    device = get_device()
+    n_samples, n_neighbors = knn_indices.shape
+
+    inds = torch.from_numpy(knn_indices.astype(np.int64)).to(device)
+    dists = torch.from_numpy(knn_dists.astype(np.float32)).to(device)
+    sig = torch.from_numpy(sigmas.astype(np.float32)).to(device)
+    rho = torch.from_numpy(rhos.astype(np.float32)).to(device)
+
+    # Row indices (sample ids)
+    sample_idx = (
+        torch.arange(n_samples, device=device).unsqueeze(1).expand_as(inds)
+    )
+
+    # Compute kernel weights: exp(-(d - rho) / sigma)
+    d = dists - rho.unsqueeze(1)
+    sigma_exp = sig.unsqueeze(1).clamp(min=1e-10)
+    vals = torch.exp(-d / sigma_exp)
+
+    # val = 0 for self-edges and missing neighbors (-1)
+    vals = torch.where(inds == sample_idx, torch.zeros_like(vals), vals)
+    vals = torch.where(inds == -1, torch.zeros_like(vals), vals)
+    # val = 1 where d <= 0 or sigma == 0 (unless self/missing)
+    close_mask = (d <= 0) | (sig.unsqueeze(1) == 0)
+    vals = torch.where(
+        close_mask & (inds != sample_idx) & (inds != -1),
+        torch.ones_like(vals),
+        vals,
+    )
+
+    rows = sample_idx.reshape(-1).cpu().numpy().astype(np.int32)
+    cols = inds.reshape(-1).cpu().numpy().astype(np.int32)
+    values = vals.reshape(-1).cpu().numpy().astype(np.float32)
+
+    return rows, cols, values
+
+
+def neighbor_graph_matrix_gpu(n_neighbors, knn_indices, knn_dists, symmetrize=True):
+    """GPU-accelerated neighbor graph matrix construction.
+
+    Parameters
+    ----------
+    n_neighbors : float
+        Effective number of neighbors for kernel width estimation.
+
+    knn_indices : ndarray of shape (n_samples, k), int32
+    knn_dists : ndarray of shape (n_samples, k), float32
+    symmetrize : bool, default=True
+
+    Returns
+    -------
+    graph : scipy sparse matrix
+        Weighted KNN graph.
+    """
+    knn_dists = knn_dists.astype(np.float32)
+
+    sigmas, rhos = smooth_knn_dist_gpu(knn_dists, float(n_neighbors))
+    rows, cols, vals = compute_membership_strengths_gpu(
+        knn_indices, knn_dists, sigmas, rhos
+    )
+
+    result = coo_array(
+        (vals, (rows, cols)),
+        shape=(knn_indices.shape[0], knn_indices.shape[0]),
+        dtype=np.float32,
+    )
+    result.eliminate_zeros()
+
+    if symmetrize:
+        transpose = result.transpose()
+        prod_matrix = result.multiply(transpose)
+        result = result + transpose - prod_matrix
+    else:
+        result = result.tocsr()
+
+    result.eliminate_zeros()
+    return result

--- a/evoc/gpu/knn_gpu.py
+++ b/evoc/gpu/knn_gpu.py
@@ -1,0 +1,201 @@
+"""GPU-accelerated brute-force k-nearest neighbor graph construction.
+
+Replaces the CPU NN-Descent algorithm with GPU matrix multiplication for
+exact KNN computation. For normalized vectors, cosine similarity is computed
+as X @ X.T, which maps perfectly to GPU GEMM operations.
+
+Supports float32 (cosine), int8 (quantized cosine), and uint8 (bit Jaccard).
+"""
+
+import numpy as np
+import torch
+
+from . import get_device, _auto_batch_size
+
+
+def knn_graph_gpu(data, n_neighbors=30, batch_size=None, verbose=False):
+    """Construct a k-nearest neighbor graph using GPU brute-force computation.
+
+    For float32 data, cosine similarity is computed via normalized matrix multiply.
+    For int8 data, inner product similarity is used.
+    For uint8 binary data, bit Jaccard similarity via unpacked matrix multiply.
+
+    Parameters
+    ----------
+    data : ndarray of shape (n_samples, n_features)
+        Input data. dtype determines the distance metric used.
+
+    n_neighbors : int, default=30
+        Number of nearest neighbors to compute for each sample.
+
+    batch_size : int or None, default=None
+        Rows to process per GPU batch. Auto-selected if None.
+
+    verbose : bool, default=False
+        If True, print progress information.
+
+    Returns
+    -------
+    indices : ndarray of shape (n_samples, n_neighbors), dtype int32
+        Indices of nearest neighbors for each sample.
+
+    distances : ndarray of shape (n_samples, n_neighbors), dtype float32
+        Transformed distances matching the CPU EVoC distance space.
+    """
+    if data.dtype == np.uint8:
+        return _knn_uint8(data, n_neighbors, batch_size, verbose)
+    elif data.dtype == np.int8:
+        return _knn_int8(data, n_neighbors, batch_size, verbose)
+    else:
+        return _knn_float(data, n_neighbors, batch_size, verbose)
+
+
+def _knn_float(data, k, batch_size, verbose):
+    """GPU KNN for float32 data using cosine similarity."""
+    device = get_device()
+    data = np.ascontiguousarray(data, dtype=np.float32)
+
+    # Normalize for cosine similarity
+    norms = np.einsum("ij,ij->i", data, data)
+    np.sqrt(norms, norms)
+    norms[norms == 0.0] = 1.0
+    if not np.allclose(norms, 1.0):
+        data = data.copy()
+        data /= norms[:, np.newaxis]
+
+    n, d = data.shape
+    k = min(k, n - 1)
+    if batch_size is None:
+        batch_size = _auto_batch_size(n, d)
+
+    data_gpu = torch.from_numpy(data).to(device)
+    indices = np.empty((n, k), dtype=np.int32)
+    distances = np.empty((n, k), dtype=np.float32)
+
+    for start in range(0, n, batch_size):
+        end = min(start + batch_size, n)
+        bsz = end - start
+
+        # Cosine similarity via matmul of normalized vectors
+        sims = torch.mm(data_gpu[start:end], data_gpu.T)
+
+        # Exclude self-similarity
+        sims[torch.arange(bsz, device=device), torch.arange(start, end, device=device)] = -2.0
+
+        topk_vals, topk_inds = torch.topk(sims, k, dim=1, sorted=True)
+
+        inds_np = topk_inds.cpu().numpy().astype(np.int32)
+        sims_np = topk_vals.cpu().numpy().astype(np.float32)
+
+        # Transform to EVoC distance space: max(-log2(cos_sim), 0)
+        # Matches CPU: heap stores -cos_sim, then max(-log2(-val), 0)
+        sims_np = np.clip(sims_np, 1e-10, 1.0)
+        distances[start:end] = np.maximum(-np.log2(sims_np), 0.0).astype(np.float32)
+        indices[start:end] = inds_np
+
+        if verbose and start % (batch_size * 10) == 0:
+            print(f"  GPU KNN: {end}/{n} samples processed")
+
+    del data_gpu
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+
+    return indices, distances
+
+
+def _knn_int8(data, k, batch_size, verbose):
+    """GPU KNN for int8 quantized embeddings via inner product."""
+    device = get_device()
+    n, d = data.shape
+    k = min(k, n - 1)
+    if batch_size is None:
+        batch_size = _auto_batch_size(n, d)
+
+    # Cast to float32 for GPU matmul
+    data_gpu = torch.from_numpy(data.astype(np.float32)).to(device)
+    indices = np.empty((n, k), dtype=np.int32)
+    distances = np.empty((n, k), dtype=np.float32)
+
+    for start in range(0, n, batch_size):
+        end = min(start + batch_size, n)
+        bsz = end - start
+
+        sims = torch.mm(data_gpu[start:end], data_gpu.T)
+        sims[torch.arange(bsz, device=device), torch.arange(start, end, device=device)] = -1e30
+
+        topk_vals, topk_inds = torch.topk(sims, k, dim=1, sorted=True)
+
+        inds_np = topk_inds.cpu().numpy().astype(np.int32)
+        sims_np = topk_vals.cpu().numpy().astype(np.float32)
+
+        # Transform: CPU does 1.0 / (-heap_val) where heap_val = -dot_product
+        sims_np = np.maximum(sims_np, 1e-10)
+        distances[start:end] = (1.0 / sims_np).astype(np.float32)
+        indices[start:end] = inds_np
+
+    del data_gpu
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+
+    return indices, distances
+
+
+def _knn_uint8(data, k, batch_size, verbose):
+    """GPU KNN for uint8 binary embeddings using bit Jaccard similarity.
+
+    Unpacks bytes to individual bits (float32) and computes Jaccard similarity
+    via matrix multiply: intersection = batch_bits @ all_bits.T
+    """
+    device = get_device()
+    n, n_bytes = data.shape
+    k = min(k, n - 1)
+
+    if batch_size is None:
+        # Smaller batches for uint8 because unpacked bits use 8x more memory
+        batch_size = _auto_batch_size(n, n_bytes * 8)
+        batch_size = min(batch_size, 2048)
+
+    # Unpack bytes to individual bits as float32 for matmul
+    bit_shifts = torch.arange(8, device=device, dtype=torch.uint8)
+    data_gpu = torch.from_numpy(data).to(device)
+    bits = ((data_gpu.unsqueeze(-1) >> bit_shifts) & 1).reshape(n, -1).float()
+    del data_gpu
+
+    # Pre-compute popcount per sample for Jaccard denominator
+    pop_all = bits.sum(dim=1, keepdim=True)  # (n, 1)
+
+    indices = np.empty((n, k), dtype=np.int32)
+    distances = np.empty((n, k), dtype=np.float32)
+
+    for start in range(0, n, batch_size):
+        end = min(start + batch_size, n)
+        bsz = end - start
+
+        batch_bits = bits[start:end]
+        pop_batch = pop_all[start:end]  # (bsz, 1)
+
+        # intersection(a, b) = dot(a_bits, b_bits) for 0/1 vectors
+        intersection = torch.mm(batch_bits, bits.T)
+        union = pop_batch + pop_all.T - intersection
+
+        # Jaccard similarity = intersection / union
+        jaccard = intersection / union.clamp(min=1.0)
+
+        # Exclude self
+        jaccard[torch.arange(bsz, device=device), torch.arange(start, end, device=device)] = -1.0
+
+        topk_vals, topk_inds = torch.topk(jaccard, k, dim=1, sorted=True)
+
+        inds_np = topk_inds.cpu().numpy().astype(np.int32)
+        sims_np = topk_vals.cpu().numpy().astype(np.float32)
+
+        # Transform: CPU does -log2(-heap_val) where heap_val = -jaccard_sim
+        sims_np = np.clip(sims_np, 1e-10, 1.0)
+        distances[start:end] = (-np.log2(sims_np)).astype(np.float32)
+        indices[start:end] = inds_np
+
+    del bits, pop_all
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+
+    return indices, distances

--- a/evoc/gpu/node_embedding_gpu.py
+++ b/evoc/gpu/node_embedding_gpu.py
@@ -1,0 +1,187 @@
+"""GPU-accelerated node embedding via edge-parallel SGD.
+
+Ports the UMAP-like graph embedding optimization to GPU using PyTorch.
+All active edges within an epoch are processed in parallel via vectorized
+gradient computation and scatter_add_ for embedding updates (Hogwild!-style).
+"""
+
+import numpy as np
+import torch
+
+from tqdm import tqdm
+
+from . import get_device
+
+
+def _make_epochs_per_sample(weights, n_epochs):
+    """Compute how frequently each edge should be sampled."""
+    n_samples = np.maximum(n_epochs * (weights / weights.max()), 1.0)
+    return (float(n_epochs) / np.float32(n_samples)).astype(np.float32)
+
+
+def node_embedding_gpu(
+    graph,
+    n_components,
+    n_epochs,
+    initial_embedding=None,
+    initial_alpha=0.5,
+    negative_sample_rate=1.0,
+    noise_level=0.5,
+    random_state=None,
+    reproducible_flag=True,
+    verbose=False,
+    tqdm_kwds=None,
+):
+    """Learn a low-dimensional embedding of a graph on GPU.
+
+    Uses edge-parallel stochastic gradient descent with attractive forces
+    on connected edges and repulsive forces on random negative pairs.
+    All active edges in an epoch are processed simultaneously.
+
+    Parameters
+    ----------
+    graph : scipy sparse matrix
+        Weighted adjacency matrix of the graph.
+
+    n_components : int
+        Number of embedding dimensions.
+
+    n_epochs : int
+        Number of training epochs.
+
+    initial_embedding : ndarray or None
+        Starting embedding. Random if None.
+
+    initial_alpha : float, default=0.5
+        Initial learning rate (decays linearly).
+
+    negative_sample_rate : float, default=1.0
+        Ratio of negative to positive samples.
+
+    noise_level : float, default=0.5
+        Controls attractive gradient strength.
+
+    random_state : RandomState or None
+        For initial embedding generation.
+
+    reproducible_flag : bool, default=True
+        Ignored on GPU (GPU operations are inherently non-deterministic).
+        Kept for API compatibility.
+
+    verbose : bool, default=False
+        Show progress bar.
+
+    tqdm_kwds : dict or None
+        Additional tqdm keyword arguments.
+
+    Returns
+    -------
+    embedding : ndarray of shape (n_vertices, n_components), float32
+    """
+    device = get_device()
+
+    if random_state is None:
+        random_state = np.random.RandomState()
+
+    n_vertices = graph.shape[0]
+
+    # Initialize embedding
+    if initial_embedding is not None:
+        embedding = torch.from_numpy(
+            np.ascontiguousarray(initial_embedding, dtype=np.float32)
+        ).to(device)
+    else:
+        embedding = (
+            torch.from_numpy(
+                random_state.normal(
+                    scale=0.25, size=(n_vertices, n_components)
+                ).astype(np.float32)
+            ).to(device)
+        )
+
+    # Prepare graph edges in COO format
+    coo = graph.tocoo()
+    head = torch.from_numpy(coo.row.astype(np.int64)).to(device)
+    tail = torch.from_numpy(coo.col.astype(np.int64)).to(device)
+    weights = coo.data.astype(np.float32)
+
+    n_edges = head.shape[0]
+    dim = n_components
+
+    # Epoch scheduling: higher-weight edges are processed more frequently
+    eps = _make_epochs_per_sample(weights, n_epochs)
+    eps_neg = (eps / negative_sample_rate).astype(np.float32)
+
+    eps_gpu = torch.from_numpy(eps).to(device)
+    eps_neg_gpu = torch.from_numpy(eps_neg).to(device)
+    epoch_of_next_sample = eps_gpu.clone()
+    epoch_of_next_neg = eps_neg_gpu.clone()
+
+    if tqdm_kwds is None:
+        tqdm_kwds = {}
+    if "disable" not in tqdm_kwds:
+        tqdm_kwds["disable"] = not verbose
+
+    for epoch in tqdm(range(n_epochs), **tqdm_kwds):
+        alpha = np.float32(initial_alpha * (1.0 - float(epoch) / float(n_epochs)))
+
+        # ---- Positive (attractive) updates ----
+        pos_mask = epoch_of_next_sample <= epoch
+        if pos_mask.any():
+            active_idx = pos_mask.nonzero(as_tuple=True)[0]
+            ah = head[active_idx]
+            at = tail[active_idx]
+
+            current = embedding[ah]  # (n_active, dim)
+            other = embedding[at]
+
+            diff = current - other
+            dist_sq = (diff * diff).sum(dim=1, keepdim=True)  # (n_active, 1)
+            dist = torch.sqrt(dist_sq.clamp(min=1e-10))
+
+            # Attractive gradient coefficient (matches CPU formula)
+            grad_coeff = (-2.0 * noise_level * dist - 2.0) / (
+                2.0 * dist_sq - 0.5 * dist + 1.0
+            )
+            grad = grad_coeff * diff * alpha
+
+            # Apply to both endpoints via atomic scatter_add_
+            embedding.scatter_add_(0, ah.unsqueeze(1).expand(-1, dim), grad)
+            embedding.scatter_add_(0, at.unsqueeze(1).expand(-1, dim), -grad)
+
+            # Advance schedule for active edges
+            epoch_of_next_sample[active_idx] += eps_gpu[active_idx]
+
+        # ---- Negative (repulsive) updates ----
+        neg_mask = epoch_of_next_neg <= epoch
+        if neg_mask.any():
+            neg_idx = neg_mask.nonzero(as_tuple=True)[0]
+            nh = head[neg_idx]
+            nt = torch.randint(0, n_vertices, (neg_idx.shape[0],), device=device)
+
+            curr_neg = embedding[nh]
+            other_neg = embedding[nt]
+
+            diff_neg = curr_neg - other_neg
+            dist_sq_neg = (diff_neg * diff_neg).sum(dim=1, keepdim=True)
+
+            # Only apply when points are far enough apart
+            valid = dist_sq_neg.squeeze(1) > 1e-2
+            grad_coeff_neg = 4.0 / (
+                (1.0 + 0.25 * dist_sq_neg) * dist_sq_neg.clamp(min=1e-10)
+            )
+            grad_neg = torch.clamp(grad_coeff_neg * diff_neg * alpha, -4.0, 4.0)
+            grad_neg[~valid] = 0.0
+
+            embedding.scatter_add_(0, nh.unsqueeze(1).expand(-1, dim), grad_neg)
+
+            epoch_of_next_neg[neg_idx] += eps_neg_gpu[neg_idx]
+
+    result = embedding.cpu().numpy()
+
+    del embedding, head, tail, eps_gpu, eps_neg_gpu
+    del epoch_of_next_sample, epoch_of_next_neg
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+
+    return result

--- a/evoc/tests/test_gpu.py
+++ b/evoc/tests/test_gpu.py
@@ -1,0 +1,285 @@
+"""Test suite for GPU-accelerated EVoC clustering.
+
+Tests are automatically skipped if no GPU backend (CUDA/MPS) is available.
+"""
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_blobs
+from sklearn.metrics import adjusted_rand_score
+
+from evoc.gpu import gpu_available
+
+# Skip entire module if no GPU
+pytestmark = pytest.mark.skipif(
+    not gpu_available(), reason="No GPU backend available (CUDA/MPS)"
+)
+
+
+@pytest.fixture
+def embedding_data():
+    """Create normalized 512-dim embedding-like data with 4 clusters."""
+    X, y = make_blobs(
+        n_samples=800, centers=4, n_features=512, cluster_std=0.8, random_state=42
+    )
+    X = X / np.linalg.norm(X, axis=1, keepdims=True)
+    return X.astype(np.float32), y
+
+
+@pytest.fixture
+def int8_data():
+    """Create int8 quantized embedding data."""
+    X, y = make_blobs(
+        n_samples=500, centers=3, n_features=128, cluster_std=1.0, random_state=42
+    )
+    X = X / np.linalg.norm(X, axis=1, keepdims=True)
+    X = (X * 127).clip(-128, 127).astype(np.int8)
+    return X, y
+
+
+@pytest.fixture
+def uint8_data():
+    """Create uint8 binary embedding data."""
+    rng = np.random.RandomState(42)
+    n_samples = 400
+    n_bytes = 64
+    # 3 clusters of random binary vectors with shared patterns
+    centers = rng.randint(0, 256, size=(3, n_bytes), dtype=np.uint8)
+    labels = rng.choice(3, size=n_samples)
+    X = np.empty((n_samples, n_bytes), dtype=np.uint8)
+    for i in range(n_samples):
+        # Flip ~20% of bits from center
+        flip_mask = rng.randint(0, 256, size=n_bytes, dtype=np.uint8)
+        flip_mask = (flip_mask < 50).astype(np.uint8) * 255
+        X[i] = centers[labels[i]] ^ flip_mask
+    return X, labels
+
+
+# ============================================================
+# GPU KNN tests
+# ============================================================
+
+
+class TestGPUKNN:
+    """Tests for GPU brute-force KNN."""
+
+    def test_knn_float_shape(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+
+        X, _ = embedding_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=15)
+        assert inds.shape == (X.shape[0], 15)
+        assert dists.shape == (X.shape[0], 15)
+        assert inds.dtype == np.int32
+        assert dists.dtype == np.float32
+
+    def test_knn_float_no_self_neighbors(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+
+        X, _ = embedding_data
+        inds, _ = knn_graph_gpu(X, n_neighbors=10)
+        for i in range(X.shape[0]):
+            assert i not in inds[i], f"Point {i} is its own neighbor"
+
+    def test_knn_float_distances_nonnegative(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+
+        X, _ = embedding_data
+        _, dists = knn_graph_gpu(X, n_neighbors=15)
+        assert np.all(dists >= 0), "Some distances are negative"
+
+    def test_knn_float_sorted(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+
+        X, _ = embedding_data
+        _, dists = knn_graph_gpu(X, n_neighbors=15)
+        # Distances should be non-decreasing per row (nearest first)
+        for i in range(min(50, X.shape[0])):
+            assert np.all(
+                np.diff(dists[i]) >= -1e-6
+            ), f"Row {i} distances not sorted"
+
+    def test_knn_int8_shape(self, int8_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+
+        X, _ = int8_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=10)
+        assert inds.shape == (X.shape[0], 10)
+        assert dists.shape == (X.shape[0], 10)
+
+    def test_knn_uint8_shape(self, uint8_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+
+        X, _ = uint8_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=10)
+        assert inds.shape == (X.shape[0], 10)
+        assert dists.shape == (X.shape[0], 10)
+
+    def test_knn_batch_sizes(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+
+        X, _ = embedding_data
+        # Small batch size forces multiple batches
+        inds1, dists1 = knn_graph_gpu(X, n_neighbors=10, batch_size=128)
+        inds2, dists2 = knn_graph_gpu(X, n_neighbors=10, batch_size=X.shape[0])
+        np.testing.assert_array_equal(inds1, inds2)
+        np.testing.assert_allclose(dists1, dists2, atol=1e-5)
+
+
+# ============================================================
+# GPU graph construction tests
+# ============================================================
+
+
+class TestGPUGraphConstruction:
+    """Tests for GPU-accelerated graph construction."""
+
+    def test_graph_shape(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+        from evoc.gpu.graph_construction_gpu import neighbor_graph_matrix_gpu
+
+        X, _ = embedding_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=15)
+        graph = neighbor_graph_matrix_gpu(15.0, inds, dists)
+        assert graph.shape == (X.shape[0], X.shape[0])
+
+    def test_graph_symmetric(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+        from evoc.gpu.graph_construction_gpu import neighbor_graph_matrix_gpu
+
+        X, _ = embedding_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=15)
+        graph = neighbor_graph_matrix_gpu(15.0, inds, dists, symmetrize=True)
+        diff = abs(graph - graph.T)
+        assert diff.max() < 1e-5, "Symmetrized graph is not symmetric"
+
+    def test_graph_weights_range(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+        from evoc.gpu.graph_construction_gpu import neighbor_graph_matrix_gpu
+
+        X, _ = embedding_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=15)
+        graph = neighbor_graph_matrix_gpu(15.0, inds, dists)
+        assert graph.data.min() >= 0, "Negative weights in graph"
+        assert graph.data.max() <= 2.0, "Unexpectedly large weights"
+
+
+# ============================================================
+# GPU node embedding tests
+# ============================================================
+
+
+class TestGPUNodeEmbedding:
+    """Tests for GPU-accelerated node embedding."""
+
+    def test_embedding_shape(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+        from evoc.gpu.graph_construction_gpu import neighbor_graph_matrix_gpu
+        from evoc.gpu.node_embedding_gpu import node_embedding_gpu
+
+        X, _ = embedding_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=15)
+        graph = neighbor_graph_matrix_gpu(15.0, inds, dists)
+        emb = node_embedding_gpu(graph, n_components=8, n_epochs=10)
+        assert emb.shape == (X.shape[0], 8)
+        assert emb.dtype == np.float32
+
+    def test_embedding_finite(self, embedding_data):
+        from evoc.gpu.knn_gpu import knn_graph_gpu
+        from evoc.gpu.graph_construction_gpu import neighbor_graph_matrix_gpu
+        from evoc.gpu.node_embedding_gpu import node_embedding_gpu
+
+        X, _ = embedding_data
+        inds, dists = knn_graph_gpu(X, n_neighbors=15)
+        graph = neighbor_graph_matrix_gpu(15.0, inds, dists)
+        emb = node_embedding_gpu(graph, n_components=8, n_epochs=20)
+        assert np.all(np.isfinite(emb)), "Embedding contains nan/inf"
+
+
+# ============================================================
+# End-to-end GPU clustering tests
+# ============================================================
+
+
+class TestGPUFullPipeline:
+    """End-to-end tests of EVoC with GPU acceleration."""
+
+    def test_evoc_clusters_gpu(self, embedding_data):
+        from evoc import evoc_clusters
+
+        X, y = embedding_data
+        result = evoc_clusters(
+            X,
+            n_neighbors=15,
+            n_epochs=20,
+            random_state=np.random.RandomState(42),
+            use_gpu=True,
+        )
+        labels = result[0][0]
+        assert labels.shape == (X.shape[0],)
+        # Should find some clusters (not all noise)
+        assert labels.max() >= 1
+
+    def test_evoc_class_gpu(self, embedding_data):
+        from evoc import EVoC
+
+        X, y = embedding_data
+        model = EVoC(
+            n_neighbors=15,
+            n_epochs=20,
+            random_state=42,
+            use_gpu=True,
+        )
+        labels = model.fit_predict(X)
+        assert labels.shape == (X.shape[0],)
+        assert labels.max() >= 1
+
+    def test_gpu_auto_mode(self, embedding_data):
+        """use_gpu='auto' should use GPU when available."""
+        from evoc import evoc_clusters
+
+        X, _ = embedding_data
+        result = evoc_clusters(
+            X,
+            n_neighbors=15,
+            n_epochs=10,
+            random_state=np.random.RandomState(42),
+            use_gpu="auto",
+        )
+        labels = result[0][0]
+        assert labels.shape == (X.shape[0],)
+
+    def test_gpu_clustering_quality(self, embedding_data):
+        """GPU clustering should achieve reasonable quality on well-separated data."""
+        from evoc import evoc_clusters
+
+        X, y = embedding_data
+        result = evoc_clusters(
+            X,
+            n_neighbors=15,
+            n_epochs=30,
+            random_state=np.random.RandomState(42),
+            use_gpu=True,
+        )
+        labels = result[0][0]
+        # Allow noise points, compute ARI on non-noise
+        mask = labels >= 0
+        if mask.sum() > 50:
+            ari = adjusted_rand_score(y[mask], labels[mask])
+            assert ari > 0.3, f"GPU clustering quality too low: ARI={ari:.3f}"
+
+    def test_gpu_approx_n_clusters(self, embedding_data):
+        from evoc import evoc_clusters
+
+        X, _ = embedding_data
+        result = evoc_clusters(
+            X,
+            n_neighbors=15,
+            n_epochs=20,
+            approx_n_clusters=4,
+            random_state=np.random.RandomState(42),
+            use_gpu=True,
+        )
+        labels = result[0][0]
+        n_clusters = len(set(labels)) - (1 if -1 in labels else 0)
+        assert 2 <= n_clusters <= 8, f"Expected ~4 clusters, got {n_clusters}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ dependencies = [
     "tqdm",
 ]
 
+[project.optional-dependencies]
+gpu = ["torch>=2.0"]
+
 [tool.setuptools]
 zip-safe = false
-packages = ["evoc"]
+packages = ["evoc", "evoc.gpu"]
 include-package-data = false


### PR DESCRIPTION
Add GPU-accelerated implementations of the three most compute-intensive steps in the EVoC pipeline:

- KNN graph: brute-force matrix multiply replaces NN-Descent, leveraging GPU GEMM for exact nearest neighbors. Supports float32 (cosine), int8 (quantized cosine), and uint8 (bit Jaccard).

- Graph construction: fully vectorized binary search for sigma/rho and parallel membership strength computation on GPU.

- Node embedding: edge-parallel SGD with scatter_add_ (Hogwild-style), processing all active edges simultaneously per epoch.

Boruvka MST and cluster tree operations remain on CPU as they operate on low-dimensional embeddings and are already fast.

New use_gpu parameter (False | True | auto) added to evoc_clusters() and EVoC class. PyTorch is an optional dependency via pip install evoc[gpu].

All 17 GPU tests + 32 existing CPU tests pass.